### PR TITLE
QA fixes.

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -117,13 +117,16 @@ if [[ $skipPrompts == true ]] || [[ $response =~ ^[yY].*$ ]]; then
 
   curl -L $gencont_sh_url -o /tmp/_gencontinuous.new
   cp /tmp/_gencontinuous.new _gencontinuous.sh
+  chmod +x _gencontinuous.sh
   rm /tmp/_gencontinuous.new
 
   curl -L $gen_sh_url -o /tmp/_genonce.new
   cp /tmp/_genonce.new _genonce.sh
+  chmod +x _genonce.sh
   rm  /tmp/_genonce.new
 
   curl -L $update_sh_url -o /tmp/_updatePublisher.new
   cp /tmp/_updatePublisher.new _updatePublisher.sh
+  chmod +x _updatePublisher.sh
   rm /tmp/_updatePublisher.new
 fi

--- a/input/fsh/ex-audit-94.fsh
+++ b/input/fsh/ex-audit-94.fsh
@@ -6,6 +6,7 @@ AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Subsc
 when creating a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyCreate] = http://hl7.org/fhir/restful-interaction#create "create"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#C
@@ -38,6 +39,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -50,6 +52,7 @@ Description:  """
 AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Registry to create a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyCreate] = http://hl7.org/fhir/restful-interaction#create "create"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#C
@@ -82,6 +85,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -95,6 +99,7 @@ AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Subsc
 when reading a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyRead] = http://hl7.org/fhir/restful-interaction#read "read"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#R
@@ -127,6 +132,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -139,6 +145,7 @@ Description:  """
 AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Registry to read a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyRead] = http://hl7.org/fhir/restful-interaction#read "read"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#R
@@ -171,6 +178,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -184,6 +192,7 @@ AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Subsc
 when updating a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyUpdate] = http://hl7.org/fhir/restful-interaction#update "update"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#U
@@ -216,6 +225,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -228,6 +238,7 @@ Description:  """
 AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Registry to update a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyUpdate] = http://hl7.org/fhir/restful-interaction#update "update"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#U
@@ -260,6 +271,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -275,6 +287,7 @@ AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Subsc
 when deleting a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyDelete] = http://hl7.org/fhir/restful-interaction#delete "delete"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#D
@@ -307,6 +320,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="
@@ -319,6 +333,7 @@ Description:  """
 AuditEvent for the PMIR Subscribe to Patient Updates by a Patient Identity Registry to delete a Subscription.
 """
 Usage:        #example
+* type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
 * subtype[anyDelete] = http://hl7.org/fhir/restful-interaction#delete "delete"
 * subtype[iti94] = urn:ihe:event-type-code#ITI-94 "Subscribe to Patient Updates"
 * action = http://hl7.org/fhir/audit-event-action#D
@@ -351,6 +366,7 @@ Usage:        #example
   * role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
   * what = Reference(Patient/ex-patient-create1)
 * entity[data]
+  * type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
   * role = http://terminology.hl7.org/CodeSystem/object-role#4 "Domain Resource"
   * what = Reference(Subscription/ex-subscription)
   * query = "UGF0aWVudD9faWQ9ZXgtcGF0aWVudA=="

--- a/input/fsh/ex-bundle.fsh
+++ b/input/fsh/ex-bundle.fsh
@@ -5,10 +5,10 @@ Description:      "IHE PMIR example Bundle for a patient that has been merged."
 Usage:            #example
 * type = #message
 * entry[PMIRMessageHeaderEntry]
-  * fullUrl = "MessageHeader/ex-messageheader-merge"
+  * fullUrl = Canonical(ex-messageheader-merge)
   * resource = ex-messageheader-merge
 * entry[PMIRBundleHistoryEntry]
-  * fullUrl = "Bundle/ex-bundle-history-merge"
+  * fullUrl = Canonical(ex-bundle-history-merge)
   * resource = ex-bundle-history-merge
 
 
@@ -20,7 +20,7 @@ Usage:            #example
 * id = "ex-bundle-history-merge"
 * type = #history
 * entry[PMIREntryUpdate]
-  * fullUrl = "http://example.com/fhir/Patient/123"
+  * fullUrl = Canonical(ex-patient-merge)
   * resource = ex-patient-merge
   * request
     * method = #PUT
@@ -45,6 +45,9 @@ Title:            "PMIR example Patient for merge"
 Description:      "Example PMIR Patient for merging."
 Usage:            #example
 * id = "ex-patient-merge"
+* text
+  * status = #additional
+  * div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Example PMIR Patient for merging</div>"
 * active = false
 * link.other = Reference(Patient/ex-patient-merged)
 * link.type = #replaced-by
@@ -55,6 +58,9 @@ Title:            "PMIR example Patient for merge"
 Description:      "Example PMIR Patient for merging."
 Usage:            #example
 * id = "ex-patient-merged"
+* text
+  * status = #additional
+  * div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Example PMIR Patient for mergin</div>"
 * active = true
 
 Instance:         ex-PMIRBundleCreate
@@ -64,10 +70,10 @@ Description:      "IHE PMIR example to create two patients."
 Usage:            #example
 * type = #message
 * entry[PMIRMessageHeaderEntry]
-  * fullUrl = "MessageHeader/ex-messageheader-create"
+  * fullUrl = Canonical(ex-messageheader-create)
   * resource = ex-messageheader-create
 * entry[PMIRBundleHistoryEntry]
-  * fullUrl = "Bundle/ex-bundle-history-create"
+  * fullUrl = Canonical(ex-bundle-history-create)
   * resource = ex-bundle-history-create
 
 
@@ -126,6 +132,9 @@ Title:            "PMIR example Patient for create"
 Description:      "Example PMIR Patient for creating."
 Usage:            #example
 * active = true
+* text
+  * status = #additional
+  * div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Example PMIR Patient for creating</div>"
 * name
   * use = #official
   * family = "Riegel"
@@ -157,6 +166,9 @@ Title:            "PMIR example Patient for create"
 Description:      "Example PMIR Patient for creating."
 Usage:            #example
 * active = true
+* text
+  * status = #additional
+  * div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Example PMIR Patient for creating</div>"
 * name
   * use = #official
   * family = "Wooten"
@@ -212,10 +224,10 @@ Description:      "IHE PMIR example to update a patient."
 Usage:            #example
 * type = #message
 * entry[PMIRMessageHeaderEntry]
-  * fullUrl = "MessageHeader/ex-messageheader-update"
+  * fullUrl = Canonical(ex-messageheader-update)
   * resource = ex-messageheader-update
 * entry[PMIRBundleHistoryEntry]
-  * fullUrl = "Bundle/ex-bundle-history-update"
+  * fullUrl = Canonical(ex-bundle-history-update)
   * resource = ex-bundle-history-update
 
 Instance:         ex-bundle-history-update 
@@ -252,6 +264,9 @@ Title:            "PMIR example Patient for update"
 Description:      "Example PMIR Patient for updating."
 Usage:            #example
 * id = "ex-patient-update"
+* text
+  * status = #additional
+  * div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Example PMIR Patient for updating</div>"
 * active = true
 * name
   * use = #official
@@ -286,10 +301,10 @@ Description:      "IHE PMIR example to delete a patient."
 Usage:            #example
 * type = #message
 * entry[PMIRMessageHeaderEntry]
-  * fullUrl = "MessageHeader/ex-messageheader-delete"
+  * fullUrl = Canonical(ex-messageheader-delete)
   * resource = ex-messageheader-delete
 * entry[PMIRBundleHistoryEntry]
-  * fullUrl = "Bundle/ex-bundle-history-delete"
+  * fullUrl = Canonical(ex-bundle-history-delete)
   * resource = ex-bundle-history-delete
 
 
@@ -301,7 +316,7 @@ Usage:            #example
 * id = "ex-bundle-history-delete"
 * type = #history
 * entry[PMIREntryDelete]
-  * fullUrl = "Patient/ex-patient-delete"
+  * fullUrl = "https://example.org/FHIR/Patient/ex-patient-delete"
   * request
     * method = #DELETE
     * url = "Patient/ex-patient-delete"

--- a/input/fsh/message.fsh
+++ b/input/fsh/message.fsh
@@ -18,11 +18,11 @@ Usage:            #definition
 * category = #notification
 * focus
   * code = #Bundle
-  * profile = "https://profiles.ihe.net/ITI/PMIR/StructureDefintion/IHE.PMIR.Bundle.History"
+  * profile = Canonical(IHE.PMIR.Bundle.History)
   * min = 1
   * max = "1"
 * responseRequired = #always
-* allowedResponse.message = "https://profiles.ihe.net/ITI/PMIR/StructureDefintion/IHE.PMIR.MessageDefinition.Response"
+* allowedResponse.message = Canonical(IHE.PMIR.MessageDefinition.Response)
 
 Instance:         IHE.PMIR.MessageDefinition.Response
 InstanceOf:       MessageDefinition
@@ -81,7 +81,7 @@ Description:      "StructureDefinition for MessageHeader resource constraints in
 * author ^requirements = "Required if known"
 * responsible MS
 * responsible ^requirements = "Required if known"
-* definition = "https://profiles.ihe.net/ITI/PMIR/StructureDefintion/IHE.PMIR.MessageDefinition"
+* definition = Canonical(IHE.PMIR.MessageDefinition)
 
 Profile:          PMIRMessageHeaderResponse
 Parent:           MessageHeader
@@ -92,4 +92,4 @@ Description:      "StructureDefinition for the PMIR MessageHeader response const
 * eventUri = "urn:ihe:iti:pmir:2019:patient-feed-response"
 * destination 0..0
 * response 1..1
-* definition = "https://profiles.ihe.net/ITI/PMIR/StructureDefintion/IHE.PMIR.MessageDefinition.Response"
+* definition = Canonical(IHE.PMIR.MessageDefinition.Response)

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,8 +1,18 @@
 == Suppressed Messages ==
 # instructions for ignoreWarnings.txt https://confluence.hl7.org/pages/viewpage.action?pageId=66938614#ImplementationGuideParameters-ManagingWarningsandHints
 # IHE valueset that is not yet a real valueset
-Code System URI 'urn:ihe:event-type-code' is unknown so the code cannot be validated
+A definition for CodeSystem 'urn:ihe:event-type-code' could not be found, so the code cannot be validated
 
 # additional codes on auditEvent.subtype are okay
 The repeating element has a pattern. The pattern will apply to all the repeats (this has not been clear to all users)
 
+# Using draft codesystems
+Reference to draft CodeSystem http://terminology.hl7.org/CodeSystem/object-role|1.0.0
+Reference to draft CodeSystem http://terminology.hl7.org/CodeSystem/audit-entity-type|1.0.0
+Reference to draft CodeSystem http://terminology.hl7.org/CodeSystem/provenance-participant-type|1.0.0
+
+# Using fixed value for constraint
+For the complex type Coding, consider using a pattern rather than a fixed value to avoid over-constraining the instance
+
+# This is expected as the eventUri is defined by PMIR
+Can't find 'urn:ihe:iti:pmir:2019:patient-feed' in the bundle (Bundle.entry[0].resource.event[x])

--- a/input/resources/CATsample1-ITI-93-mother.xml
+++ b/input/resources/CATsample1-ITI-93-mother.xml
@@ -11,6 +11,7 @@
     <fullUrl value="http://proxy:11254/PatientIdentityManager/fhir/MessageHeader/070b3907-883b-4f20-af66-88a5db6b73ad"/>
     <resource>
       <MessageHeader xmlns="http://hl7.org/fhir">
+        <id value="070b3907-883b-4f20-af66-88a5db6b73ad"/>
         <meta>
           <profile value="https://profiles.ihe.net/ITI/PMIR/StructureDefinition/IHE.PMIR.MessageHeader"/>
         </meta>
@@ -35,7 +36,7 @@
           <endpoint value="urn:oid:1.3.6.1.4.1.21367.13.10.345"/>
         </source>
         <focus>
-          <reference value="Bundle/070b3907-883b-4f20-af66-88a5db6b73ad"/>
+          <reference value="http://proxy:11254/PatientIdentityManager/fhir/Bundle/070b3907-883b-4f20-af66-88a5db6b73ad"/>
         </focus>
       </MessageHeader>
     </resource>
@@ -53,6 +54,11 @@
           <fullUrl value="http://proxy:11254/PatientIdentityManager/fhir/Patient/110fd932-7368-4d2a-acbd-1f5d28bf95d6"/>
           <resource>
             <Patient xmlns="http://hl7.org/fhir">
+              <id value="110fd932-7368-4d2a-acbd-1f5d28bf95d6"/>
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>
                 <value value="Mother"/>

--- a/input/resources/CATsample2-ITI-93-mother.xml
+++ b/input/resources/CATsample2-ITI-93-mother.xml
@@ -18,13 +18,13 @@
           <code value="ok"/>
         </response>
         <focus>
-          <reference value="http://172-223-006-088.res.spectrum.com:18035/PatientIdentityManager/fhir/Patient/8f33f71d-497c-eb11-95e7-d067e54cbc0c"/>
+          <reference value="http://172-223-006-088.res.spectrum.com:18035/PatientIdentityManager/fhir/Bundle/8f52a376-d6d2-46ab-a810-c4233bd46c69"/>
         </focus>
       </MessageHeader>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="http://172-223-006-088.res.spectrum.com:18035/PatientIdentityManager/fhir/Patient/8f33f71d-497c-eb11-95e7-d067e54cbc0c"/>
+    <fullUrl value="http://172-223-006-088.res.spectrum.com:18035/PatientIdentityManager/fhir/Bundle/8f52a376-d6d2-46ab-a810-c4233bd46c69"/>
     <resource>
       <Bundle>
         <id value="8f52a376-d6d2-46ab-a810-c4233bd46c69"/>
@@ -38,6 +38,10 @@
               <meta>
                 <lastUpdated value="2021-03-03T12:51:45.173-05:00"/>
               </meta>
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <use value="usual"/>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>

--- a/input/resources/CATsample3-ITI-93-baby.xml
+++ b/input/resources/CATsample3-ITI-93-baby.xml
@@ -11,6 +11,7 @@
     <fullUrl value="http://proxy:11254/PatientIdentityManager/fhir/MessageHeader/76354729-8458-434c-ace5-007e6ff32464"/>
     <resource>
       <MessageHeader xmlns="http://hl7.org/fhir">
+        <id value="76354729-8458-434c-ace5-007e6ff32464"/>
         <meta>
           <profile value="https://profiles.ihe.net/ITI/PMIR/StructureDefinition/IHE.PMIR.MessageHeader"/>
         </meta>
@@ -35,7 +36,7 @@
           <endpoint value="urn:oid:1.3.6.1.4.1.21367.13.10.345"/>
         </source>
         <focus>
-          <reference value="Bundle/76354729-8458-434c-ace5-007e6ff32464"/>
+          <reference value="http://proxy:11254/PatientIdentityManager/fhir/Bundle/76354729-8458-434c-ace5-007e6ff32464"/>
         </focus>
       </MessageHeader>
     </resource>
@@ -53,6 +54,10 @@
           <fullUrl value="urn:uuid:cb80f151-8209-46b8-87e8-b0c20186b654"/>
           <resource>
             <Patient xmlns="http://hl7.org/fhir">
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>
                 <value value="Child"/>

--- a/input/resources/CATsample4-ITI-93-baby.xml
+++ b/input/resources/CATsample4-ITI-93-baby.xml
@@ -38,6 +38,10 @@
               <meta>
                 <lastUpdated value="2021-03-03T16:56:18.573-05:00"/>
               </meta>
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <use value="usual"/>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>

--- a/input/resources/CATsample6-ITI-93-updateBaby.xml
+++ b/input/resources/CATsample6-ITI-93-updateBaby.xml
@@ -11,6 +11,7 @@
     <fullUrl value="http://proxy:11254/PatientIdentityManager/fhir/MessageHeader/76c55983-0800-41f2-80b7-a49719e8334d"/>
     <resource>
       <MessageHeader xmlns="http://hl7.org/fhir">
+        <id value="76c55983-0800-41f2-80b7-a49719e8334d"/>
         <meta>
           <profile value="https://profiles.ihe.net/ITI/PMIR/StructureDefinition/IHE.PMIR.MessageHeader"/>
         </meta>
@@ -35,7 +36,7 @@
           <endpoint value="urn:oid:1.3.6.1.4.1.21367.13.10.345"/>
         </source>
         <focus>
-          <reference value="Bundle/76c55983-0800-41f2-80b7-a49719e8334d"/>
+          <reference value="http://proxy:11254/PatientIdentityManager/fhir/Bundle/76c55983-0800-41f2-80b7-a49719e8334d"/>
         </focus>
       </MessageHeader>
     </resource>
@@ -53,6 +54,11 @@
           <fullUrl value="http://proxy:11254/PatientIdentityManager/fhir/Patient/e8f9de72-4398-4351-8f19-a5e14835a1d3"/>
           <resource>
             <Patient xmlns="http://hl7.org/fhir">
+              <id value="e8f9de72-4398-4351-8f19-a5e14835a1d3"/>
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>
                 <value value="Child"/>

--- a/input/resources/CATsample7-ITI-93-merge.xml
+++ b/input/resources/CATsample7-ITI-93-merge.xml
@@ -11,6 +11,7 @@
     <fullUrl value="http://gazelle-proxy:11254/PatientIdentityManager/fhir/MessageHeader/6119323c-93c7-4972-9ba7-f90686f6c370"/>
     <resource>
       <MessageHeader xmlns="http://hl7.org/fhir">
+        <id value="6119323c-93c7-4972-9ba7-f90686f6c370"/>
         <meta>
           <profile value="https://profiles.ihe.net/ITI/PMIR/StructureDefinition/IHE.PMIR.MessageHeader"/>
         </meta>
@@ -35,7 +36,7 @@
           <endpoint value="urn:oid:1.3.6.1.4.1.21367.13.10.345"/>
         </source>
         <focus>
-          <reference value="Bundle/6119323c-93c7-4972-9ba7-f90686f6c370"/>
+          <reference value="http://gazelle-proxy:11254/PatientIdentityManager/fhir/Bundle/6119323c-93c7-4972-9ba7-f90686f6c370"/>
         </focus>
       </MessageHeader>
     </resource>
@@ -57,6 +58,10 @@
               <meta>
                 <profile value="https://profiles.ihe.net/ITI/PMIR/StructureDefinition/IHE.PMIR.Patient.Merge"/>
               </meta>
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>
                 <value value="ONE"/>

--- a/input/resources/CATsample8-ITI-93-merge.xml
+++ b/input/resources/CATsample8-ITI-93-merge.xml
@@ -38,6 +38,10 @@
               <meta>
                 <lastUpdated value="2021-03-04T09:38:25.137-05:00"/>
               </meta>
+              <text>
+                <status value="additional"/>
+                <div xmlns="http://www.w3.org/1999/xhtml">Connectathon Example Patient</div>
+              </text>
               <identifier>
                 <use value="usual"/>
                 <system value="urn:oid:1.3.6.1.4.1.21367.13.20.308"/>

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -29,7 +29,8 @@ jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 copyrightYear: 2022+
 dependencies:
   ihe.iti.balp: current # 1.1.1
-
+  ihe.iti.pdqm: 3.0.0
+  ihe.iti.pixm: 3.0.4
 
 parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
   path-resource:


### PR DESCRIPTION
## 📑 Description
QA fixes for IG publisher

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
There was an informational message about eventUri.  I believe we may need a CP around this and it should be changed to eventCoding.  

There was also some oddities around `AuditEvent.type`.  These may be build issues with the publisher.  When it was inheriting the `type` from BALP, it complained about `coding.display` not being present.  If I added it to my profile it gave an error about building the differential.  If I added it to the example everything was happy.  So this may be a non-issue.  This may also be related to the current build 1.1.0 of BALP as github has the `display` commented out when setting it.  Also, I don't know if case really matters, but the terminology server has changed the display for 'rest' from "Restful Operation" to "RESTful Operation".